### PR TITLE
Tiny changes to READMEs

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 [![CRAN status](https://www.r-pkg.org/badges/version/ggbump)](https://CRAN.R-project.org/package=ggbump)
 [![R build status](https://github.com/davidsjoberg/ggbump/workflows/R-CMD-check/badge.svg)](https://github.com/davidsjoberg/ggbump/actions)
-[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/ggbump)
+[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/ggbump)](https://cranlogs.r-pkg.org/badges/ggbump)
 <!-- badges: end -->
 
 The R package `ggbump` creates elegant bump charts in ggplot. Bump charts are good

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 [![CRAN status](https://www.r-pkg.org/badges/version/ggbump)](https://CRAN.R-project.org/package=ggbump)
-[![R build status](https://github.com/HaydenMacDonald/ggbump/workflows/R-CMD-check/badge.svg)](https://github.com/HaydenMacDonald/ggbump/actions)
+[![R build status](https://github.com/davidsjoberg/ggbump/workflows/R-CMD-check/badge.svg)](https://github.com/davidsjoberg/ggbump/actions)
 [![CRAN Downloads](https://cranlogs.r-pkg.org/badges/ggbump)
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ experimental](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https:/
 status](https://www.r-pkg.org/badges/version/ggbump)](https://CRAN.R-project.org/package=ggbump)
 [![R build
 status](https://github.com/davidsjoberg/ggbump/workflows/R-CMD-check/badge.svg)](https://github.com/davidsjoberg/ggbump/actions)
-\[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/ggbump)
+[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/ggbump)
 <!-- badges: end -->
 
 The R package `ggbump` creates elegant bump charts in ggplot. Bump

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ experimental](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https:/
 status](https://www.r-pkg.org/badges/version/ggbump)](https://CRAN.R-project.org/package=ggbump)
 [![R build
 status](https://github.com/davidsjoberg/ggbump/workflows/R-CMD-check/badge.svg)](https://github.com/davidsjoberg/ggbump/actions)
-[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/ggbump)
+[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/ggbump)](https://cranlogs.r-pkg.org/badges/ggbump)
 <!-- badges: end -->
 
 The R package `ggbump` creates elegant bump charts in ggplot. Bump

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ experimental](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https:/
 [![CRAN
 status](https://www.r-pkg.org/badges/version/ggbump)](https://CRAN.R-project.org/package=ggbump)
 [![R build
-status](https://github.com/HaydenMacDonald/ggbump/workflows/R-CMD-check/badge.svg)](https://github.com/HaydenMacDonald/ggbump/actions)
+status](https://github.com/davidsjoberg/ggbump/workflows/R-CMD-check/badge.svg)](https://github.com/davidsjoberg/ggbump/actions)
 \[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/ggbump)
 <!-- badges: end -->
 


### PR DESCRIPTION
Hi there!

I was working on a completely separate project and realized that I probably never changed the badge url for the GitHub Actions workflows to represent the correct repo. It turns out that I was right. This change will ensure all future test results on `master` will actually be reflected in the GitHub Actions badge in README.Rmd and README.md. Additionally, I fixed a small error on the README files related to the CRAN download badge.

Let me know if you have any questions/concerns.

Cheers!