### PR TITLE
Provide compute_group default arguments

### DIFF
--- a/R/geom_bump.R
+++ b/R/geom_bump.R
@@ -15,7 +15,7 @@ StatBump <- ggplot2::ggproto("StatBump", ggplot2::Stat,
                                  as.data.frame()
                                data
                              },
-                             compute_group = function(data, scales, smooth, direction) {
+                             compute_group = function(data, scales, smooth = 8, direction = "x") {
                                data <- data %>%
                                  dplyr::arrange(x)
 

--- a/R/geom_sigmoid.R
+++ b/R/geom_sigmoid.R
@@ -9,7 +9,7 @@ StatSigmoid <- ggplot2::ggproto("StatSigmoid", ggplot2::Stat,
                                   data %>% print()
                                   data
                                 },
-                                compute_group = function(data, scales, smooth, direction) {
+                                compute_group = function(data, scales, smooth = 8, direction = "x") {
                                   out <- sigmoid(data$x, data$xend, data$y, data$yend,
                                                  smooth = smooth, direction = direction)
                                   out


### PR DESCRIPTION
Related to #20, if we want to use `stat = StatBump` we *have* to provide the `smooth` and `direction` arguments. With this PR, the defaults are set in the `Stat*$compute_group()` methods, so we don't *need* to.